### PR TITLE
Fix base type detecting in MonoCustomAttrs for return parameter

### DIFF
--- a/mcs/class/corlib/System/MonoCustomAttrs.cs
+++ b/mcs/class/corlib/System/MonoCustomAttrs.cs
@@ -626,6 +626,8 @@ namespace System
 					MethodInfo bmethod = ((RuntimeMethodInfo)method).GetBaseMethod ();
 					if (bmethod == method)
 						return null;
+					if (parinfo.Position == -1)
+						return bmethod.ReturnParameter;
 					return bmethod.GetParameters ()[parinfo.Position];
 				}
 			}


### PR DESCRIPTION

<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
